### PR TITLE
Resolve error "Creating default object from empty value"

### DIFF
--- a/api/ExactTarget.class.php
+++ b/api/ExactTarget.class.php
@@ -40,7 +40,7 @@ class ExactTarget {
 	}
 
 	public function updateSettings($object = false) {
-		$api->lastError = '';
+		if($object !== false) $object->lastError = '';
 		$settings = get_option("gf_exacttarget_settings");
 		if(!$settings || !is_array($settings)) { return; }
 		foreach($settings as $key => $value) {


### PR DESCRIPTION
See related support threads:

http://wordpress.org/support/topic/gravity-forms-exacttarget-add-on-conflicting-with-latest-version-1
http://wordpress.org/support/topic/error-message-warning-creating-default-object-from-empty-value

Current version displays following error on ExactTarget settings page and upon any form submission:

```
Warning: Creating default object from empty value in D:\WebSites\berry-r00-dev-web\wp-content\plugins\gravity-forms-exacttarget\api\ExactTarget.class.php on line 43
```

Using current plugin versions as of pull request.
- Gravity Forms 1.8.8.9
- Gravity Forms ExactTarget Add-On 1.0.6
