### PR TITLE
The application was static calling three non-static methods, so we made ...

### DIFF
--- a/exacttarget.php
+++ b/exacttarget.php
@@ -121,7 +121,7 @@ class GFExactTarget {
         }
     }
 
-    function settings_link( $links, $file ) {
+    public static function settings_link( $links, $file ) {
         static $this_plugin;
         if( ! $this_plugin ) $this_plugin = plugin_basename(__FILE__);
         if ( $file == $this_plugin ) {
@@ -1340,12 +1340,12 @@ class GFExactTarget {
     }
 
     //Returns the url of the plugin's root folder
-    protected function get_base_url(){
+    protected static function get_base_url(){
         return plugins_url(null, __FILE__);
     }
 
     //Returns the physical path of the plugin's root folder
-    protected function get_base_path(){
+    protected static function get_base_path(){
         $folder = basename(dirname(__FILE__));
         return WP_PLUGIN_DIR . "/" . $folder;
     }


### PR DESCRIPTION
...them static. This eliminates the warnings that PHP was showing on the plugins' page on WP.
